### PR TITLE
docs(governance): add PR template and ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owners for governance, docs, and workflow files
+* @Hangi-n42
+
+# Collaboration and policy surfaces
+/.github/ @Hangi-n42
+/CONTRIBUTING.md @Hangi-n42
+/docs/ @Hangi-n42
+/scripts/ @Hangi-n42
+/frontend/ @Hangi-n42
+/app/ @Hangi-n42

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# Summary
+
+Describe what this PR changes and why.
+
+## Branch Strategy
+
+- Branch name: feature/<topic>, fix/<topic>, or docs/<topic>
+- Base branch: main
+- Commit type: feat, fix, docs, chore, or refactor
+
+## Review Evidence
+
+- [ ] At least 3 review comments were collected.
+- [ ] At least one review comment used a [MUST] tag.
+- [ ] Any follow-up feedback is reflected in follow-up commits.
+
+## Checklist
+
+- [ ] The PR follows Conventional Commits.
+- [ ] The change is isolated to a feature branch.
+- [ ] Relevant docs were updated.
+- [ ] Review comments were addressed.
+- [ ] The change is ready for merge.
+
+## Notes for Reviewers
+
+- Highlight blockers with `[MUST]`.
+- Use `[SHOULD]` for improvements that are not blocking.
+- Keep each review comment focused on a single issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing Guide
+
+This repository uses a feature-branch workflow with Conventional Commits and pull-request based review.
+
+## Branch Strategy
+
+- `main`: protected release branch.
+- `feature/<topic>`: isolated work for a single task or PR.
+- `fix/<topic>`: hotfixes and small corrections.
+- `docs/<topic>`: documentation-only changes.
+- Keep branch names short, descriptive, and aligned to the PR title.
+
+## Commit Format
+
+Use Conventional Commits for every commit:
+
+- `feat`: new user-facing capability
+- `fix`: bug fix
+- `docs`: documentation only
+- `chore`: tooling or maintenance
+- `refactor`: internal change without behavior change
+
+Examples:
+
+```text
+feat(docs): add branch strategy and review guide
+docs(wiki): add getting started page
+chore(ci): draft SLA workflow skeleton
+```
+
+Commit messages should describe one logical change only. If a PR needs follow-up work after review, use a new Conventional Commit in the same branch instead of rewriting history.
+
+## Pull Request Flow
+
+1. Create a feature branch from `main`.
+2. Keep commits small and reviewable.
+3. Open one PR per logical change.
+4. Link the issue or task description in the PR body.
+5. Request review from the code owners.
+6. Address feedback with follow-up commits.
+7. Collect at least 3 review comments before merge, with at least one tagged `[MUST]` or `[SHOULD]`.
+
+## Review Rules
+
+- Use `[MUST]` for blockers, correctness issues, or missing requirements.
+- Use `[SHOULD]` for quality, readability, or follow-up recommendations.
+- Keep each review comment focused on a single finding.
+- Prefer concrete examples over vague advice.
+- When reviewing, state the risk, the location, and the expected fix in one comment.
+
+## Definition of Done
+
+- Changes are committed with a Conventional Commit message.
+- PR template is completed.
+- Review feedback is addressed.
+- Relevant docs and tests are updated.
+- Branch protection expectations are documented before merge.

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,34 @@
+# Branch Protection Rules Draft
+
+Target branch: `main`
+
+Recommended rules:
+
+- Require pull request reviews before merging.
+- Require at least 1 approving review.
+- Dismiss stale reviews when new commits are pushed.
+- Require status checks to pass before merging.
+- Require branches to be up to date before merging.
+- Restrict direct pushes to `main`.
+- Require linear history if squash/rebase merges are the standard.
+
+Required collaboration flow:
+
+- Work on `feature/<topic>`, `fix/<topic>`, or `docs/<topic>` branches only.
+- Use Conventional Commits for every commit pushed to the feature branch.
+- Open a PR only after the branch is ready for review.
+- Collect at least 3 review comments and address all `[MUST]` items before merge.
+
+Suggested status checks:
+
+- CI / test workflow
+- DORA metrics workflow
+- Documentation lint if enabled later
+
+Suggested merge settings:
+
+- Allow squash merge if you want one Conventional Commit style summary on `main`.
+- Dismiss stale approvals when the branch changes.
+- Require at least one code owner review if CODEOWNERS is enabled.
+
+Note: This file documents the policy. Apply the same policy in repository settings or rulesets if you have admin access.

--- a/docs/review-guide.md
+++ b/docs/review-guide.md
@@ -1,0 +1,30 @@
+# Review Guide
+
+## Goal
+
+Review PRs with actionable feedback that can be applied quickly.
+
+## Tagging Rules
+
+- `[MUST]` means the PR should not merge until the item is fixed.
+- `[SHOULD]` means the PR can merge, but the recommendation should be considered.
+
+## Review Minimum
+
+- Leave at least 3 review comments for each PR when possible.
+- Include at least one `[MUST]` finding if you identify a blocker.
+- Use the remaining comments for `[SHOULD]` improvements, clarity notes, or small follow-ups.
+
+## Example Review Comments
+
+- `[MUST]` The branch protection rule is described in docs, but the repository settings are still not enforced. Please apply the corresponding rule in GitHub settings or rulesets before merging.
+- `[MUST]` The workflow draft should fail fast when the expected input is missing so CI does not silently pass with empty output.
+- `[SHOULD]` The wiki pages would be easier to scan if each page ended with a short related-links section.
+
+## Review Checklist
+
+- Check correctness first.
+- Check whether the change meets the task.
+- Check whether the commit message follows Conventional Commits.
+- Check whether documentation and links remain consistent.
+- Check whether the PR has enough review evidence to support merge.


### PR DESCRIPTION
Adds a concise PR template, CODEOWNERS coverage, and review evidence checks.