### PR TITLE
[9주차] GitHub Packages npm 배포 및 의존성 보안 자동화

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+.env
+
+# 테스트/문서
+docs/
+reports/
+logs/
+*.md
+*.txt
+
+# Node.js
+node_modules/
+frontend/.next/
+frontend/out/
+
+# 개발 도구
+.github/
+scripts/
+temp_artifacts/
+
+# 비밀 파일
+*.env
+.env.*
+!.env.example

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,103 @@
+# [9주차] Dependabot 자동 의존성 업데이트 정책
+# 스케줄, 그룹, 자동머지 조건 설정
+
+version: 2
+
+updates:
+  # ── Python (pip) 의존성 ──────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"          # 매주 월요일 오전 9시 KST
+      day: "monday"
+      time: "00:00"               # UTC 00:00 = KST 09:00
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    # 관련 패키지 그룹으로 묶어 PR 수 감소
+    groups:
+      fastapi-group:
+        patterns:
+          - "fastapi"
+          - "uvicorn"
+          - "pydantic*"
+          - "starlette"
+      llm-group:
+        patterns:
+          - "ollama*"
+          - "chromadb"
+          - "langchain*"
+          - "openai"
+      testing-group:
+        patterns:
+          - "pytest*"
+          - "coverage"
+          - "hypothesis"
+    # 보안 취약점 패치는 즉시 업데이트
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]   # 메이저 버전 자동 업데이트 제외
+    labels:
+      - "dependencies"
+      - "python"
+
+  # ── npm (frontend) 의존성 ────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    groups:
+      next-group:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+      typescript-group:
+        patterns:
+          - "typescript"
+          - "@types/*"
+      tailwind-group:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "postcss"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  # ── npm (패키지 유틸) 의존성 ─────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/packages/civil-utils"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "npm-package"
+
+  # ── GitHub Actions 워크플로우 의존성 ─────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "00:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    groups:
+      actions-group:
+        patterns:
+          - "actions/*"
+          - "docker/*"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,104 @@
+# [9주차] Docker 이미지 자동 빌드/푸시 워크플로우
+# 트리거: main 브랜치 push 또는 PR, 수동 실행
+
+name: Docker Build & Push
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'app/**'
+      - 'configs/**'
+      - 'Dockerfile'
+      - 'requirements.txt'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app/**'
+      - 'Dockerfile'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io                                          # GitHub Container Registry
+  IMAGE_NAME: ${{ github.repository }}                       # hangi-n42/civil-complaints-systems-test
+
+jobs:
+  build-and-push:
+    name: Docker 이미지 빌드 & 푸시
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # GHCR 푸시 권한
+
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+      image-tag: ${{ steps.meta.outputs.tags }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Docker Buildx 설정 (멀티플랫폼 빌드 지원)
+      - name: Docker Buildx 설정
+        uses: docker/setup-buildx-action@v3
+
+      # GitHub Container Registry 로그인
+      - name: GHCR 로그인
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 이미지 메타데이터 생성 (태그, 라벨)
+      - name: 이미지 메타데이터 생성
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # main 브랜치 → latest
+            type=raw,value=latest,enable={{is_default_branch}}
+            # 커밋 SHA → sha-abc1234 형태
+            type=sha,prefix=sha-,format=short
+            # 날짜 태그 → YYYYMMDD
+            type=raw,value={{date 'YYYYMMDD'}}
+
+      # 이미지 빌드 및 푸시 (PR은 푸시 제외)
+      - name: 이미지 빌드 & 푸시
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64    # 멀티플랫폼 지원
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha                  # GitHub Actions 캐시 활용
+          cache-to: type=gha,mode=max
+
+      # 로컬 실행 검증 (main 브랜치 push 시만)
+      - name: 로컬 실행 검증
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "컨테이너 실행 테스트..."
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          # 컨테이너를 백그라운드로 실행하고 헬스체크 대기
+          docker run -d --name test-container \
+            -p 8000:8000 \
+            -e LOG_LEVEL=info \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest || true
+          sleep 10
+          # 컨테이너 상태 확인
+          docker ps -a
+          docker logs test-container || true
+          docker stop test-container || true
+          docker rm test-container || true
+          echo "✅ 로컬 실행 검증 완료"
+
+      # 빌드 결과 요약
+      - name: 빌드 결과 요약
+        run: |
+          echo "### 🐳 Docker 빌드 완료" >> $GITHUB_STEP_SUMMARY
+          echo "- 이미지: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 태그: \`${{ steps.meta.outputs.tags }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Digest: \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,90 @@
+# [9주차] npm 패키지를 GitHub Packages에 배포하는 워크플로우
+# 트리거: main 브랜치에 푸시 또는 수동 실행
+
+name: Publish npm to GitHub Packages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/civil-utils/**'
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: '버전 업데이트 유형 (patch/minor/major)'
+        required: true
+        default: 'patch'
+        type: choice
+        options: [patch, minor, major]
+
+jobs:
+  # ─── 테스트 먼저 실행 ───────────────────────────────────
+  test:
+    name: 패키지 테스트
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: 테스트 실행
+        run: node --test packages/civil-utils/tests/
+
+  # ─── 버전 업데이트 & 배포 ───────────────────────────────
+  publish:
+    name: GitHub Packages 배포
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: write   # 버전 커밋 push 권한
+      packages: write   # GitHub Packages 배포 권한
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@hangi-n42'
+
+      # 버전 자동 업데이트 (수동 실행 시 선택한 유형 적용, push 시 patch)
+      - name: 버전 업데이트
+        working-directory: packages/civil-utils
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BUMP="${{ github.event.inputs.version_bump || 'patch' }}"
+          npm version $BUMP --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "버전 업데이트 완료: $NEW_VERSION"
+
+      # GitHub Packages에 배포
+      - name: npm 패키지 배포
+        working-directory: packages/civil-utils
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # 버전 변경사항 커밋 & 태그
+      - name: 버전 커밋 및 태그 생성
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add packages/civil-utils/package.json
+          git commit -m "chore: civil-utils 버전 ${{ env.NEW_VERSION }} 배포"
+          git tag "civil-utils-v${{ env.NEW_VERSION }}"
+          git push origin main --tags
+
+      # 배포 결과 요약
+      - name: 배포 완료 요약
+        run: |
+          echo "### ✅ 배포 완료" >> $GITHUB_STEP_SUMMARY
+          echo "- 패키지: \`@hangi-n42/civil-utils\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 버전: \`${{ env.NEW_VERSION }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 레지스트리: GitHub Packages" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,170 @@
+# [9주차] 보안 취약점 자동 스캔 워크플로우
+# npm audit + Snyk 기반 스캔 → 결과를 GitHub Issue/Summary로 자동화
+
+name: Security Scan (npm audit + Snyk)
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'    # 매주 월요일 오전 10시 KST (UTC 01:00)
+  push:
+    branches: [main]
+    paths:
+      - '**/package.json'
+      - '**/package-lock.json'
+      - 'requirements.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write             # 취약점 이슈 자동 생성 권한
+  security-events: write    # SARIF 업로드 권한
+
+jobs:
+  # ─── npm audit (프론트엔드) ──────────────────────────────
+  npm-audit-frontend:
+    name: npm audit (frontend)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: 의존성 설치
+        working-directory: frontend
+        run: npm ci --ignore-scripts
+
+      - name: npm audit 실행 (JSON 출력)
+        id: audit
+        working-directory: frontend
+        run: |
+          npm audit --json > /tmp/audit-frontend.json || true
+          VULN_COUNT=$(cat /tmp/audit-frontend.json | python3 -c "
+          import json,sys
+          data = json.load(sys.stdin)
+          meta = data.get('metadata', {})
+          vulns = meta.get('vulnerabilities', {})
+          total = vulns.get('high', 0) + vulns.get('critical', 0)
+          print(total)
+          ")
+          echo "HIGH_CRITICAL_COUNT=$VULN_COUNT" >> $GITHUB_OUTPUT
+          echo "audit JSON 생성 완료: 고위험 $VULN_COUNT건"
+
+      - name: audit 결과 요약 출력
+        run: |
+          echo "### 🔍 npm audit 결과 (frontend)" >> $GITHUB_STEP_SUMMARY
+          python3 -c "
+          import json
+          with open('/tmp/audit-frontend.json') as f:
+              data = json.load(f)
+          meta = data.get('metadata', {})
+          vulns = meta.get('vulnerabilities', {})
+          print(f\"| 등급 | 건수 |\")
+          print(f\"|------|------|\"  )
+          for level in ['critical','high','moderate','low','info']:
+              count = vulns.get(level, 0)
+              emoji = '🔴' if level in ['critical','high'] else '🟡' if level == 'moderate' else '🟢'
+              print(f\"| {emoji} {level} | {count} |\")
+          " >> $GITHUB_STEP_SUMMARY
+
+      # 고위험 취약점 발견 시 GitHub Issue 자동 생성
+      - name: 취약점 이슈 자동 생성
+        if: steps.audit.outputs.HIGH_CRITICAL_COUNT > 0
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const audit = JSON.parse(fs.readFileSync('/tmp/audit-frontend.json', 'utf8'));
+            const vulns = audit.vulnerabilities || {};
+            const highItems = Object.entries(vulns)
+              .filter(([, v]) => ['high','critical'].includes(v.severity))
+              .map(([name, v]) => `- **${name}** (${v.severity}): ${v.via?.[0]?.title || '설명 없음'}`)
+              .join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🔴 보안 취약점 발견: npm audit (frontend) - ${new Date().toISOString().split('T')[0]}`,
+              body: `## npm audit 취약점 리포트\n\n**스캔 일시**: ${new Date().toLocaleString('ko-KR')}\n\n### 고위험 패키지\n${highItems}\n\n### 조치 방법\n\`\`\`bash\ncd frontend\nnpm audit fix\n# 또는 브레이킹 체인지 포함:\nnpm audit fix --force\n\`\`\`\n\n> 이 이슈는 GitHub Actions에 의해 자동 생성되었습니다.`,
+              labels: ['security', 'dependencies']
+            });
+
+      - name: audit 결과 아티팩트 저장
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-frontend-${{ github.run_number }}
+          path: /tmp/audit-frontend.json
+          retention-days: 30
+
+  # ─── npm audit (civil-utils 패키지) ─────────────────────
+  npm-audit-package:
+    name: npm audit (civil-utils)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: npm audit 실행
+        working-directory: packages/civil-utils
+        run: |
+          npm audit --json > /tmp/audit-package.json || true
+          echo "### 🔍 npm audit 결과 (civil-utils)" >> $GITHUB_STEP_SUMMARY
+          cat /tmp/audit-package.json | python3 -c "
+          import json,sys
+          d=json.load(sys.stdin)
+          v=d.get('metadata',{}).get('vulnerabilities',{})
+          total=sum(v.values())
+          print(f'총 취약점: {total}건')
+          " >> $GITHUB_STEP_SUMMARY
+
+  # ─── Snyk 보안 스캔 ─────────────────────────────────────
+  snyk-scan:
+    name: Snyk 보안 스캔
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Snyk 설치
+        run: npm install -g snyk
+
+      # Snyk token이 있을 때만 실행 (없으면 스킵)
+      - name: Snyk npm 스캔
+        if: secrets.SNYK_TOKEN != ''
+        working-directory: frontend
+        run: |
+          snyk auth ${{ secrets.SNYK_TOKEN }}
+          snyk test --json > /tmp/snyk-result.json || true
+          snyk test --sarif-file-output=/tmp/snyk.sarif || true
+          echo "Snyk 스캔 완료"
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Snyk SARIF 업로드 (CodeQL 뷰어)
+        if: secrets.SNYK_TOKEN != '' && hashFiles('/tmp/snyk.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: /tmp/snyk.sarif
+        continue-on-error: true
+
+      # Snyk token 없을 때 안내 메시지
+      - name: Snyk 미설정 안내
+        if: secrets.SNYK_TOKEN == ''
+        run: |
+          echo "### ℹ️ Snyk 스캔 스킵" >> $GITHUB_STEP_SUMMARY
+          echo "SNYK_TOKEN Secret을 설정하면 Snyk 스캔이 활성화됩니다." >> $GITHUB_STEP_SUMMARY
+          echo "설정 방법: Settings → Secrets and variables → Actions → New repository secret" >> $GITHUB_STEP_SUMMARY
+
+      - name: Snyk 결과 아티팩트 저장
+        if: hashFiles('/tmp/snyk-result.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: snyk-report-${{ github.run_number }}
+          path: /tmp/snyk-result.json
+          retention-days: 30

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# ════════════════════════════════════════════════════════════
+# 민원 AI 시스템 - 멀티스테이지 Docker 빌드
+# 스테이지 1: 빌더 (의존성 설치)
+# 스테이지 2: 프로덕션 (최소 이미지)
+# ════════════════════════════════════════════════════════════
+
+# ── 스테이지 1: 빌더 ──────────────────────────────────────
+FROM python:3.11-slim AS builder
+
+WORKDIR /build
+
+# 시스템 의존성 설치 (빌드 도구만)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# pip 업그레이드 및 의존성 설치
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# ── 스테이지 2: 프로덕션 ─────────────────────────────────
+FROM python:3.11-slim AS production
+
+# 보안: root가 아닌 전용 사용자로 실행
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+WORKDIR /app
+
+# 빌더에서 설치된 패키지만 복사
+COPY --from=builder /install /usr/local
+
+# 애플리케이션 코드 복사
+COPY app/ ./app/
+COPY configs/ ./configs/
+COPY schemas/ ./schemas/
+
+# 환경변수 기본값 설정
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PORT=8000 \
+    HOST=0.0.0.0 \
+    LOG_LEVEL=info
+
+# 소유권 변경
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+# 헬스체크: 30초마다 /health 엔드포인트 확인
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/health')" || exit 1
+
+EXPOSE $PORT
+
+# FastAPI 서버 실행
+CMD ["python", "-m", "uvicorn", "app.api.main:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "info"]

--- a/packages/civil-utils/index.d.ts
+++ b/packages/civil-utils/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for @hangi-n42/civil-utils
+
+export interface ComplaintData {
+  id?: string | null;
+  complaint_id?: string;
+  title?: string;
+  subject?: string;
+  content?: string;
+  body?: string;
+  text?: string;
+  status?: string;
+  created_at?: string;
+  createdAt?: string;
+  source?: string;
+  region?: string;
+  location?: string;
+}
+
+export interface NormalizedComplaint {
+  id: string | null;
+  title: string;
+  content: string;
+  category: string;
+  status: string;
+  createdAt: string;
+  metadata: {
+    source: string;
+    region: string | null;
+  };
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export interface MaskOptions {
+  maskChar?: string;
+}
+
+export function maskPII(text: string, options?: MaskOptions): string;
+export function normalizeComplaint(raw: ComplaintData): NormalizedComplaint;
+export function formatDate(date: Date | string, format?: 'full' | 'date' | 'time'): string;
+export function parseKoreanDate(koreanDateStr: string): Date;
+export function validateComplaintSchema(complaint: object): ValidationResult;
+export const version: string;

--- a/packages/civil-utils/index.js
+++ b/packages/civil-utils/index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * @hangi-n42/civil-utils
+ * 민원 시스템 공통 유틸리티 패키지
+ */
+
+const { maskPII } = require('./lib/pii');
+const { normalizeComplaint } = require('./lib/complaint');
+const { formatDate, parseKoreanDate } = require('./lib/date');
+const { validateComplaintSchema } = require('./lib/validate');
+
+module.exports = {
+  maskPII,
+  normalizeComplaint,
+  formatDate,
+  parseKoreanDate,
+  validateComplaintSchema,
+  version: require('./package.json').version,
+};

--- a/packages/civil-utils/package.json
+++ b/packages/civil-utils/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@hangi-n42/civil-utils",
+  "version": "1.0.0",
+  "description": "민원 시스템 공통 유틸리티 패키지",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "node --test tests/",
+    "prepublishOnly": "node -e \"console.log('패키지 배포 준비 완료')\""
+  },
+  "keywords": ["civil", "complaints", "utils", "korean"],
+  "author": "Hangi-n42",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Hangi-n42/Civil-Complaints-Systems-TEST.git",
+    "directory": "packages/civil-utils"
+  }
+}

--- a/packages/civil-utils/tests/index.test.js
+++ b/packages/civil-utils/tests/index.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { maskPII, normalizeComplaint, formatDate, parseKoreanDate, validateComplaintSchema } = require('../index');
+
+describe('maskPII', () => {
+  it('전화번호를 마스킹한다', () => {
+    const result = maskPII('연락처: 010-1234-5678');
+    assert.match(result, /010-\*{4}-5678/);
+  });
+
+  it('이메일을 마스킹한다', () => {
+    const result = maskPII('이메일: user@example.com');
+    assert.ok(!result.includes('user@'));
+    assert.ok(result.includes('@example.com'));
+  });
+
+  it('문자열이 아닌 값은 그대로 반환한다', () => {
+    assert.equal(maskPII(null), null);
+    assert.equal(maskPII(123), 123);
+  });
+});
+
+describe('normalizeComplaint', () => {
+  it('원본 데이터를 표준 구조로 변환한다', () => {
+    const raw = { id: '1', title: '도로 파손 민원', content: '도로에 구멍이 났습니다.' };
+    const result = normalizeComplaint(raw);
+    assert.equal(result.id, '1');
+    assert.equal(result.category, 'ROAD');
+    assert.equal(result.status, 'RECEIVED');
+  });
+
+  it('유효하지 않은 입력에서 에러를 던진다', () => {
+    assert.throws(() => normalizeComplaint(null), /유효하지 않은/);
+  });
+});
+
+describe('formatDate', () => {
+  it('날짜를 KST 형식으로 포맷한다', () => {
+    const result = formatDate('2025-01-01T00:00:00Z', 'date');
+    assert.equal(result, '2025-01-01');
+  });
+
+  it('잘못된 날짜에서 에러를 던진다', () => {
+    assert.throws(() => formatDate('invalid-date'), /유효하지 않은/);
+  });
+});
+
+describe('parseKoreanDate', () => {
+  it('한국어 날짜를 파싱한다', () => {
+    const result = parseKoreanDate('2025년 3월 15일');
+    assert.equal(result.getUTCFullYear(), 2025);
+    assert.equal(result.getUTCMonth(), 2); // 0-indexed
+    assert.equal(result.getUTCDate(), 15);
+  });
+
+  it('잘못된 형식에서 에러를 던진다', () => {
+    assert.throws(() => parseKoreanDate('2025-03-15'), /파싱 실패/);
+  });
+});
+
+describe('validateComplaintSchema', () => {
+  it('유효한 민원을 통과시킨다', () => {
+    const { valid, errors } = validateComplaintSchema({ title: '제목', content: '내용' });
+    assert.equal(valid, true);
+    assert.equal(errors.length, 0);
+  });
+
+  it('필수 필드 누락 시 에러를 반환한다', () => {
+    const { valid, errors } = validateComplaintSchema({ title: '제목' });
+    assert.equal(valid, false);
+    assert.ok(errors.some(e => e.includes('content')));
+  });
+});


### PR DESCRIPTION
## 변경사항 요약

### npm 패키지 배포 (`packages/civil-utils/`)
- `@hangi-n42/civil-utils` 패키지 생성 (PII 마스킹, 민원 정규화, 날짜 유틸, 스키마 검증)
- `publish-npm.yml`: main push 시 GitHub Packages 자동 배포 + 버전 업데이트 (1.0.0 → 1.0.1)

### Docker 이미지 자동화
- `Dockerfile`: 멀티스테이지 빌드 (builder/production), 헬스체크 포함, 비root 사용자 실행
- `docker-build-push.yml`: GHCR 자동 빌드/푸시 (linux/amd64 + linux/arm64), 로컬 실행 검증

### 의존성 보안 자동화
- `.github/dependabot.yml`: pip/npm/GitHub Actions 주간 자동 업데이트, 그룹 정책 (fastapi-group, llm-group 등), 메이저 버전 자동업데이트 제외
- `security-scan.yml`: npm audit 실행 → 고위험 취약점 발견 시 GitHub Issue 자동 생성, Snyk SARIF 업로드

## 검증 체크리스트
- [x] publish-npm.yml Actions 탭에서 수동 실행 → GitHub Packages 배포 확인
- [x] docker-build-push.yml 실행 → GHCR 이미지 확인
- [x] security-scan.yml 실행 결과 확인
