### PR TITLE
[10주차] 멀티 플랫폼 배포 자동화 (GitHub Pages + AWS Lambda)

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,0 +1,152 @@
+# [10주차] AWS 서버리스 배포 자동화 워크플로우
+# AWS Lambda (서버리스) + 헬스체크/모니터링 설정
+# Mangum을 사용해 FastAPI → Lambda 어댑터
+
+name: Deploy to AWS Lambda (Serverless)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'app/**'
+      - 'requirements.txt'
+      - '.github/workflows/deploy-cloud.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: '배포 환경'
+        required: true
+        default: 'staging'
+        type: choice
+        options: [staging, production]
+
+env:
+  AWS_REGION: ap-northeast-2          # 서울 리전
+  LAMBDA_FUNCTION_NAME: civil-api-${{ github.event.inputs.environment || 'staging' }}
+  ECR_REPOSITORY: civil-complaints-api
+
+permissions:
+  contents: read
+  id-token: write    # AWS OIDC 인증
+
+jobs:
+  # ─── 빌드 & ECR 푸시 ────────────────────────────────────
+  build-and-push:
+    name: Lambda 이미지 빌드 & ECR 푸시
+    runs-on: ubuntu-latest
+    outputs:
+      image-uri: ${{ steps.push.outputs.image-uri }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # AWS OIDC 인증 (키 없이 안전하게 인증)
+      - name: AWS 인증
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: ECR 로그인
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: 이미지 빌드 & ECR 푸시
+        id: push
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          ECR_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}"
+          IMAGE_TAG="${{ github.sha }}"
+
+          docker build -t "${ECR_URI}:${IMAGE_TAG}" -t "${ECR_URI}:latest" .
+          docker push "${ECR_URI}:${IMAGE_TAG}"
+          docker push "${ECR_URI}:latest"
+
+          echo "image-uri=${ECR_URI}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "ECR 푸시 완료: ${ECR_URI}:${IMAGE_TAG}"
+
+  # ─── Lambda 배포 ─────────────────────────────────────────
+  deploy-lambda:
+    name: Lambda 함수 업데이트
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment:
+      name: ${{ github.event.inputs.environment || 'staging' }}
+
+    steps:
+      - name: AWS 인증
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Lambda 이미지 업데이트
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ env.LAMBDA_FUNCTION_NAME }} \
+            --image-uri ${{ needs.build-and-push.outputs.image-uri }} \
+            --region ${{ env.AWS_REGION }}
+
+          # 업데이트 완료 대기 (최대 5분)
+          aws lambda wait function-updated \
+            --function-name ${{ env.LAMBDA_FUNCTION_NAME }}
+          echo "Lambda 업데이트 완료"
+
+  # ─── 헬스체크 & 모니터링 검증 ───────────────────────────
+  health-check:
+    name: 헬스체크 & 모니터링 검증
+    runs-on: ubuntu-latest
+    needs: deploy-lambda
+
+    steps:
+      - name: AWS 인증
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # API Gateway URL로 헬스체크 엔드포인트 호출
+      - name: 헬스체크 엔드포인트 확인
+        run: |
+          ENDPOINT="${{ secrets.API_GATEWAY_URL }}/health"
+          echo "헬스체크 URL: $ENDPOINT"
+
+          for i in 1 2 3; do
+            STATUS=$(curl -s -o /tmp/health-response.json -w "%{http_code}" "$ENDPOINT" || echo "000")
+            echo "시도 $i: HTTP $STATUS"
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ 헬스체크 통과"
+              cat /tmp/health-response.json
+              break
+            fi
+            sleep 10
+          done
+
+          if [ "$STATUS" != "200" ]; then
+            echo "❌ 헬스체크 실패: HTTP $STATUS"
+            exit 1
+          fi
+
+      # CloudWatch 알람 상태 확인
+      - name: CloudWatch 알람 확인
+        run: |
+          ALARM_STATE=$(aws cloudwatch describe-alarms \
+            --alarm-names "civil-api-error-rate" \
+            --query 'MetricAlarms[0].StateValue' \
+            --output text 2>/dev/null || echo "ALARM_NOT_FOUND")
+
+          echo "알람 상태: $ALARM_STATE"
+          if [ "$ALARM_STATE" = "ALARM" ]; then
+            echo "⚠️ CloudWatch 알람 발생! 배포를 재확인하세요."
+          else
+            echo "✅ 알람 정상"
+          fi
+        continue-on-error: true
+
+      - name: 배포 결과 요약
+        run: |
+          echo "### 🚀 AWS Lambda 배포 완료" >> $GITHUB_STEP_SUMMARY
+          echo "- 함수: \`${{ env.LAMBDA_FUNCTION_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 리전: \`${{ env.AWS_REGION }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 이미지: \`${{ needs.build-and-push.outputs.image-uri }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 헬스체크: ✅ 통과" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,82 @@
+# [10주차] GitHub Pages 프론트엔드 자동 배포 워크플로우
+# main 브랜치 push 시 Next.js 빌드 → GitHub Pages 배포
+
+name: Deploy Frontend to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write           # Pages 배포 권한
+  id-token: write        # OIDC 토큰 (Pages 인증)
+
+# 동시 배포 방지: 진행 중인 배포가 있으면 취소하지 않고 대기
+concurrency:
+  group: pages-deployment
+  cancel-in-progress: false
+
+jobs:
+  # ─── 빌드 ──────────────────────────────────────────────
+  build:
+    name: Next.js 빌드
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: GitHub Pages 설정 감지
+        id: pages
+        uses: actions/configure-pages@v4
+        with:
+          static_site_generator: next
+
+      - name: 의존성 설치
+        working-directory: frontend
+        run: npm ci
+
+      # Next.js 정적 내보내기 빌드
+      - name: 프론트엔드 빌드 (정적 내보내기)
+        working-directory: frontend
+        run: npm run build
+        env:
+          # GitHub Pages는 /Civil-Complaints-Systems-TEST/ 경로로 서빙됨
+          NEXT_PUBLIC_BASE_PATH: /Civil-Complaints-Systems-TEST
+          NEXT_PUBLIC_DEPLOY_ENV: production
+          NEXT_PUBLIC_BUILD_TIME: ${{ github.run_id }}
+
+      - name: 빌드 결과물 업로드
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/out
+
+  # ─── 배포 ──────────────────────────────────────────────
+  deploy:
+    name: GitHub Pages 배포
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: GitHub Pages 배포
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: 배포 완료 요약
+        run: |
+          echo "### 🚀 배포 완료" >> $GITHUB_STEP_SUMMARY
+          echo "- URL: ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "- 브랜치: \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 커밋: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,118 @@
+# [10주차] PR 프리뷰 환경 자동 구성 워크플로우
+# PR 생성/업데이트 시 Vercel Preview 배포 또는 GitHub Pages 브랜치 배포
+
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'frontend/**'
+
+permissions:
+  contents: write
+  pull-requests: write     # PR 코멘트 권한
+  deployments: write
+
+jobs:
+  # ─── PR 열림/업데이트 시: 프리뷰 빌드 & 배포 ──────────
+  deploy-preview:
+    name: PR 프리뷰 배포
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: 의존성 설치
+        working-directory: frontend
+        run: npm ci
+
+      - name: 프리뷰 빌드
+        working-directory: frontend
+        run: npm run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /Civil-Complaints-Systems-TEST/preview/pr-${{ github.event.number }}
+          NEXT_PUBLIC_DEPLOY_ENV: preview
+          NEXT_PUBLIC_PR_NUMBER: ${{ github.event.number }}
+
+      # gh-pages 브랜치의 preview/pr-{N} 경로에 배포
+      - name: GitHub Pages 프리뷰 경로 배포
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: frontend/out
+          destination_dir: preview/pr-${{ github.event.number }}
+          keep_files: true
+          commit_message: "preview: PR #${{ github.event.number }} 프리뷰 배포"
+
+      # PR에 프리뷰 URL 코멘트 자동 추가
+      - name: PR 프리뷰 URL 코멘트
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://hangi-n42.github.io/Civil-Complaints-Systems-TEST/preview/pr-${prNumber}/`;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+
+            // 기존 프리뷰 코멘트 찾기
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.data.find(c =>
+              c.body.includes('🔍 PR 프리뷰 배포') && c.user.type === 'Bot'
+            );
+
+            const body = `## 🔍 PR 프리뷰 배포\n\n| 항목 | 내용 |\n|------|------|\n| 🌐 프리뷰 URL | [열기](${previewUrl}) |\n| 📝 커밋 | \`${sha}\` |\n| ⏱️ 배포 시각 | ${new Date().toLocaleString('ko-KR', {timeZone: 'Asia/Seoul'})} |\n\n> 이 PR이 닫히면 프리뷰는 자동으로 삭제됩니다.`;
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  # ─── PR 닫힘 시: 프리뷰 정리 ──────────────────────────
+  cleanup-preview:
+    name: PR 프리뷰 정리
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 프리뷰 디렉토리 삭제
+        run: |
+          PR_DIR="preview/pr-${{ github.event.number }}"
+          if [ -d "$PR_DIR" ]; then
+            rm -rf "$PR_DIR"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "cleanup: PR #${{ github.event.number }} 프리뷰 삭제"
+            git push
+            echo "프리뷰 삭제 완료: $PR_DIR"
+          else
+            echo "삭제할 프리뷰 없음: $PR_DIR"
+          fi
+        continue-on-error: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,102 @@
+# [10주차] Docker 기반 배포 파이프라인 전략
+# 전체 스택(API + Frontend + ChromaDB) 로컬/프로덕션 실행
+
+version: '3.9'
+
+services:
+  # ─── FastAPI 백엔드 ─────────────────────────────────────
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    image: ghcr.io/hangi-n42/civil-complaints-systems-test:latest
+    container_name: civil-api
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      - PORT=8000
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - CHROMADB_HOST=chromadb
+      - CHROMADB_PORT=8001
+      # Ollama는 호스트에서 실행 (GPU 활용)
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+    env_file:
+      - .env
+    depends_on:
+      chromadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    volumes:
+      - ./logs:/app/logs        # 로그 영속화
+    networks:
+      - civil-network
+
+  # ─── Next.js 프론트엔드 ──────────────────────────────────
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.frontend
+    container_name: civil-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://api:8000
+      - NEXT_PUBLIC_DEPLOY_ENV=${DEPLOY_ENV:-production}
+    depends_on:
+      api:
+        condition: service_healthy
+    networks:
+      - civil-network
+
+  # ─── ChromaDB 벡터 데이터베이스 ─────────────────────────
+  chromadb:
+    image: chromadb/chroma:latest
+    container_name: civil-chromadb
+    restart: unless-stopped
+    ports:
+      - "8001:8000"
+    volumes:
+      - chromadb-data:/chroma/chroma   # 벡터 데이터 영속화
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - civil-network
+
+  # ─── Nginx 리버스 프록시 (프로덕션용) ───────────────────
+  nginx:
+    image: nginx:alpine
+    container_name: civil-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./configs/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./configs/nginx/ssl:/etc/nginx/ssl:ro
+    depends_on:
+      - api
+      - frontend
+    networks:
+      - civil-network
+    profiles:
+      - production    # docker compose --profile production up 으로 활성화
+
+volumes:
+  chromadb-data:
+    driver: local
+
+networks:
+  civil-network:
+    driver: bridge

--- a/docs/deployment/deployment-strategy.md
+++ b/docs/deployment/deployment-strategy.md
@@ -1,0 +1,88 @@
+# 배포 파이프라인 전략 설계
+
+## 개요
+
+민원 AI 시스템의 멀티 플랫폼 배포 전략입니다.
+
+## 아키텍처
+
+```
+┌─────────────────────────────────────────────────┐
+│                  GitHub main 브랜치               │
+└──────────┬──────────────────────┬───────────────┘
+           │                      │
+    ┌──────▼──────┐        ┌──────▼──────┐
+    │  프론트엔드  │        │  백엔드 API  │
+    │ (Next.js)   │        │  (FastAPI)   │
+    └──────┬──────┘        └──────┬──────┘
+           │                      │
+    ┌──────▼──────┐        ┌──────▼──────┐
+    │GitHub Pages │        │ AWS Lambda  │
+    │  (정적 SPA)  │        │  (서버리스)  │
+    └─────────────┘        └─────────────┘
+```
+
+## 환경 구성
+
+| 환경 | 트리거 | 프론트엔드 | 백엔드 | 목적 |
+|------|--------|-----------|--------|------|
+| **preview** | PR 생성/업데이트 | GitHub Pages (pr-N/) | 없음 | 코드 리뷰 |
+| **staging** | main push | GitHub Pages | AWS Lambda (staging) | 통합 테스트 |
+| **production** | 수동 트리거 | GitHub Pages | AWS Lambda (prod) | 운영 |
+
+## 배포 파이프라인
+
+### 프론트엔드 (Next.js → GitHub Pages)
+
+```
+PR 열림 → 프리뷰 빌드 → preview/pr-{N}/ 배포 → PR 코멘트에 URL 추가
+main push → 프로덕션 빌드 → GitHub Pages 배포
+PR 닫힘 → 프리뷰 디렉토리 자동 삭제
+```
+
+**설정 필요 사항 (저장소 Settings):**
+1. Settings → Pages → Source: `gh-pages` 브랜치
+2. `next.config.ts`에 `output: 'export'` 및 `basePath` 설정
+
+### 백엔드 (FastAPI → AWS Lambda)
+
+```
+main push → Docker 빌드 → ECR 푸시 → Lambda 이미지 업데이트
+→ Lambda 준비 대기 → 헬스체크 (/health) → CloudWatch 알람 확인
+```
+
+**필요한 GitHub Secrets:**
+- `AWS_ROLE_ARN`: AWS IAM Role ARN (OIDC 연동)
+- `API_GATEWAY_URL`: API Gateway 엔드포인트 URL
+
+### Docker Compose (로컬/온프레미스)
+
+```bash
+# 개발 환경
+docker compose up -d
+
+# 프로덕션 (Nginx 포함)
+docker compose --profile production up -d
+```
+
+## 헬스체크 엔드포인트
+
+모든 환경에서 `/health` 엔드포인트가 응답해야 합니다.
+
+```json
+{
+  "status": "ok",
+  "version": "1.0.0",
+  "timestamp": "2026-05-31T00:00:00Z",
+  "services": {
+    "chromadb": "ok",
+    "ollama": "ok"
+  }
+}
+```
+
+## 롤백 전략
+
+- **Lambda**: 이전 버전으로 즉시 전환 (`aws lambda update-alias`)
+- **GitHub Pages**: 이전 커밋으로 `git revert` 후 재배포
+- **Docker**: 이전 이미지 태그로 `docker compose` 재실행


### PR DESCRIPTION
## 변경사항 요약

### 프론트엔드 자동 배포
- `deploy-pages.yml`: main push 시 Next.js 정적 빌드 → GitHub Pages 자동 배포
- `pr-preview.yml`: PR 생성 시 `preview/pr-{N}/` 경로 자동 배포, PR 닫히면 자동 정리, PR 코멘트에 URL 추가

### Docker 배포 전략
- `docker-compose.yml`: API + Frontend + ChromaDB + Nginx 전체 스택 구성, 헬스체크 포함
- `docs/deployment/deployment-strategy.md`: 환경별(preview/staging/production) 배포 전략 문서

### 클라우드 배포 (AWS Lambda 서버리스)
- `deploy-cloud.yml`: AWS OIDC 인증 → ECR 빌드/푸시 → Lambda 이미지 업데이트 → 헬스체크 → CloudWatch 알람 확인

## 설정 필요
- Settings → Pages → Source: **GitHub Actions** 선택
- `frontend/next.config.ts`에 `output: 'export'` 추가 필요

## 배포 URL
- GitHub Pages: https://hangi-n42.github.io/Civil-Complaints-Systems-TEST/
